### PR TITLE
Added support for floodgate, fixed help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@ This means you can easily migrate your existing whitelists.
 
 ## Commands & Permissions
 
-| Command                            | Description                                                                     | Permission              |
-|------------------------------------|---------------------------------------------------------------------------------|-------------------------|
-| `/globalwhitelist add <player>`    | Add a player to the whitelist                                                   | `globalwhitelist`       |
-| `/globalwhitelist remove <player>` | Remove a player from the whitelist                                              | `globalwhitelist`       |
-| `/globalwhitelist list`            | Displays all players in the whitelist                                           | `globalwhitelist`       |
-| `/globalwhitelist on`              | Enable the whitelist                                                            | `globalwhitelist.admin` |
-| `/globalwhitelist off`             | Disable the whitelist                                                           | `globalwhitelist.admin` |
-| `/globalwhitelist enforced`        | Enforce the whitelist. Players not on the whitelist (if enabled) will be kicked | `globalwhitelist.admin` |
-| `/globalwhitelist unenforced`      | Disable enforcement. Players not on the whitelist will not be kicked            | `globalwhitelist.admin` |
-| `/globalwhitelist reload`          | Reload the whitelist configuration                                              | `globalwhitelist.admin` |
+| Command                                      | Description                                                                     | Permission              |
+|----------------------------------------------|---------------------------------------------------------------------------------|-------------------------|
+| `/globalwhitelist help`                      | Display the help section                                                        | `globalwhitelist`       |
+| `/globalwhitelist add <player>`              | Add a player to the whitelist                                                   | `globalwhitelist`       |
+| `/globalwhitelist remove <player>`           | Remove a player from the whitelist                                              | `globalwhitelist`       |
+| `/globalwhitelist floodgate_add <player>`    | Add a bedrock player to the whitelist                                           | `globalwhitelist`       |
+| `/globalwhitelist floodgate_remove <player>` | Remove a bedrock player from the whitelist                                      | `globalwhitelist`       |
+| `/globalwhitelist list`                      | Displays all players in the whitelist                                           | `globalwhitelist`       |
+| `/globalwhitelist on`                        | Enable the whitelist                                                            | `globalwhitelist.admin` |
+| `/globalwhitelist off`                       | Disable the whitelist                                                           | `globalwhitelist.admin` |
+| `/globalwhitelist enforced`                  | Enforce the whitelist. Players not on the whitelist (if enabled) will be kicked | `globalwhitelist.admin` |
+| `/globalwhitelist unenforced`                | Disable enforcement. Players not on the whitelist will not be kicked            | `globalwhitelist.admin` |
+| `/globalwhitelist reload`                    | Reload the whitelist configuration                                              | `globalwhitelist.admin` |

--- a/src/main/java/com/uravgcode/globalwhitelist/command/WhitelistCommand.java
+++ b/src/main/java/com/uravgcode/globalwhitelist/command/WhitelistCommand.java
@@ -34,6 +34,9 @@ public final class WhitelistCommand {
             .then(buildOffCommand(commandHandler))
             .then(buildEnforcedCommand(commandHandler))
             .then(buildUnenforcedCommand(commandHandler))
+            .then(buildFloodgateRemoveCommand(commandHandler))
+            .then(buildFloodgateAddCommand(commandHandler))
+            .then(buildHelpCommand(commandHandler))
             .build();
 
         return new BrigadierCommand(rootNode);
@@ -47,12 +50,28 @@ public final class WhitelistCommand {
                 .executes(handler::add));
     }
 
+    private static LiteralArgumentBuilder<CommandSource> buildFloodgateAddCommand(WhitelistCommandHandler handler) {
+        return BrigadierCommand.literalArgumentBuilder("floodgate_add")
+            .requires(source -> source.hasPermission(PERMISSION_BASE) || source.hasPermission(PERMISSION_ADMIN))
+            .then(BrigadierCommand.requiredArgumentBuilder("player", StringArgumentType.word())
+                .suggests(handler::suggestOnlinePlayers)
+                .executes(handler::floodgate_add));
+    }
+
     private static LiteralArgumentBuilder<CommandSource> buildRemoveCommand(WhitelistCommandHandler handler) {
         return BrigadierCommand.literalArgumentBuilder("remove")
             .requires(source -> source.hasPermission(PERMISSION_BASE) || source.hasPermission(PERMISSION_ADMIN))
             .then(BrigadierCommand.requiredArgumentBuilder("player", StringArgumentType.word())
                 .suggests(handler::suggestWhitelistedPlayers)
                 .executes(handler::remove));
+    }
+
+    private static LiteralArgumentBuilder<CommandSource> buildFloodgateRemoveCommand(WhitelistCommandHandler handler) {
+        return BrigadierCommand.literalArgumentBuilder("floodgate_remove")
+            .requires(source -> source.hasPermission(PERMISSION_BASE) || source.hasPermission(PERMISSION_ADMIN))
+            .then(BrigadierCommand.requiredArgumentBuilder("player", StringArgumentType.word())
+                .suggests(handler::suggestWhitelistedPlayers)
+                .executes(handler::floodgate_remove));
     }
 
     private static LiteralArgumentBuilder<CommandSource> buildListCommand(WhitelistCommandHandler handler) {
@@ -89,5 +108,11 @@ public final class WhitelistCommand {
         return BrigadierCommand.literalArgumentBuilder("reload")
             .requires(source -> source.hasPermission(PERMISSION_ADMIN))
             .executes(handler::reload);
+    }
+
+    private static LiteralArgumentBuilder<CommandSource> buildHelpCommand(WhitelistCommandHandler handler) {
+        return BrigadierCommand.literalArgumentBuilder("help")
+            .requires(source -> source.hasPermission(PERMISSION_BASE))
+            .executes(handler::help);
     }
 }

--- a/src/main/java/com/uravgcode/globalwhitelist/command/WhitelistCommandHandler.java
+++ b/src/main/java/com/uravgcode/globalwhitelist/command/WhitelistCommandHandler.java
@@ -40,7 +40,22 @@ public record WhitelistCommandHandler(
         var source = context.getSource();
         var playerName = context.getArgument("player", String.class);
 
-        profileService.getProfile(playerName).ifPresentOrElse(player -> {
+        profileService.getProfile(playerName, false).ifPresentOrElse(player -> {
+            if (whitelist.add(player)) {
+                source.sendMessage(messages.getMessage(MessagesConfig.WHITELIST_ADD_SUCCESS, playerName));
+            } else {
+                source.sendMessage(messages.getMessage(MessagesConfig.WHITELIST_ADD_ALREADY_WHITELISTED, playerName));
+            }
+        }, () -> source.sendMessage(messages.getMessage(MessagesConfig.WHITELIST_PLAYER_DOES_NOT_EXIST, playerName)));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    public int floodgate_add(CommandContext<CommandSource> context) {
+        var source = context.getSource();
+        var playerName = context.getArgument("player", String.class);
+
+        profileService.getProfile(playerName, true).ifPresentOrElse(player -> {
             if (whitelist.add(player)) {
                 source.sendMessage(messages.getMessage(MessagesConfig.WHITELIST_ADD_SUCCESS, playerName));
             } else {
@@ -55,7 +70,25 @@ public record WhitelistCommandHandler(
         var source = context.getSource();
         var playerName = context.getArgument("player", String.class);
 
-        profileService.getProfile(playerName).ifPresentOrElse(player -> {
+        profileService.getProfile(playerName, false).ifPresentOrElse(player -> {
+            if (whitelist.remove(player)) {
+                source.sendMessage(messages.getMessage(MessagesConfig.WHITELIST_REMOVE_SUCCESS, playerName));
+                if (config.whitelistEnabled() && config.enforceWhitelistEnabled()) {
+                    proxy.getPlayer(playerName).ifPresent(p -> p.disconnect(messages.getMessage(MessagesConfig.WHITELIST_REJECTED)));
+                }
+            } else {
+                source.sendMessage(messages.getMessage(MessagesConfig.WHITELIST_REMOVE_NOT_WHITELISTED, playerName));
+            }
+        }, () -> source.sendMessage(messages.getMessage(MessagesConfig.WHITELIST_PLAYER_DOES_NOT_EXIST, playerName)));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    public int floodgate_remove(CommandContext<CommandSource> context) {
+        var source = context.getSource();
+        var playerName = context.getArgument("player", String.class);
+
+        profileService.getProfile(playerName, true).ifPresentOrElse(player -> {
             if (whitelist.remove(player)) {
                 source.sendMessage(messages.getMessage(MessagesConfig.WHITELIST_REMOVE_SUCCESS, playerName));
                 if (config.whitelistEnabled() && config.enforceWhitelistEnabled()) {

--- a/src/main/java/com/uravgcode/globalwhitelist/config/MessagesConfig.java
+++ b/src/main/java/com/uravgcode/globalwhitelist/config/MessagesConfig.java
@@ -79,7 +79,7 @@ public class MessagesConfig {
     }
 
     private void loadDefaults() {
-        messages.setProperty(WHITELIST_HELP, "<red>/globalwhitelist <add|remove|list|on|off|enforce|unenforce|reload>");
+        messages.setProperty(WHITELIST_HELP, "<red>/globalwhitelist <add|remove|list|on|off|enforce|unenforce|reload|floodgate_add|floodgate_remove>");
 
         messages.setProperty(WHITELIST_ADD_SUCCESS, "Added <player> to the whitelist");
         messages.setProperty(WHITELIST_ADD_ALREADY_WHITELISTED, "<red>Player is already whitelisted");


### PR DESCRIPTION
This patch allows bedrock players joining through Geyser/Floodgate to be added to the whitelist. It fetches their UUID and username from the Geyser API and then is added as if it was a java player. It also fixes the help command which was previously unusable. I have built and tested this on my own Minecraft server and am currently using it.